### PR TITLE
Make behaviour for going to top/bottom more less-like

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -92,7 +92,11 @@ impl Prompt {
                 KeyCode::Char('n') => Some(Cmd::SearchNext),
                 KeyCode::Char('N') => Some(Cmd::SearchPrev),
                 KeyCode::Char('g') => {
-                    if let Ok(x) = self.input.parse::<usize>() {
+                    if self.input.is_empty() {
+                        // `less` goes to the top by default if there's no input
+                        // for `g`.
+                        Some(Cmd::RowTop)
+                    } else if let Ok(x) = self.input.parse::<usize>() {
                         self.input.clear();
                         Some(Cmd::RowGoTo(x.saturating_sub(1)))
                     } else {

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -70,7 +70,7 @@ impl Prompt {
                 KeyCode::Left | KeyCode::Char('h') => Some(Cmd::ColLeft),
                 KeyCode::Down | KeyCode::Char('j') => Some(Cmd::RowDown),
                 KeyCode::Up | KeyCode::Char('k') => Some(Cmd::RowUp),
-                KeyCode::End | KeyCode::Char('G') => Some(Cmd::RowBottom),
+                KeyCode::End | KeyCode::Char('G') | KeyCode::Char('>') => Some(Cmd::RowBottom),
                 KeyCode::Char('F') | KeyCode::Char('f') => {
                     self.mode = Mode::Follow;
                     Some(Cmd::Redraw)
@@ -91,7 +91,7 @@ impl Prompt {
                 }
                 KeyCode::Char('n') => Some(Cmd::SearchNext),
                 KeyCode::Char('N') => Some(Cmd::SearchPrev),
-                KeyCode::Char('g') => {
+                KeyCode::Char('g') | KeyCode::Char('<') => {
                     if self.input.is_empty() {
                         // `less` goes to the top by default if there's no input
                         // for `g`.


### PR DESCRIPTION
I mainly just wanted to add the `<` and `>` but `g` was easy to fix too. It seems `G` ignores the input though, probably should do the same thing as `g`.